### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,6 +3,8 @@ name: Build Minecraft Forge Docker Image
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   build-minecraft-forge:


### PR DESCRIPTION
Potential fix for [https://github.com/vxgxp/forge-minecraft-linux-installer/security/code-scanning/1](https://github.com/vxgxp/forge-minecraft-linux-installer/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily interacts with Docker Hub and builds/pushes Docker images, it likely only needs `contents: read` permissions. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build-minecraft-forge` job. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
